### PR TITLE
Standardize job step names in CI workflows by capitalizing "Refresh c…

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -54,7 +54,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      - name: refresh container
+      - name: Refresh container
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.SSH_HOST }}

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -54,7 +54,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      - name: refresh container
+      - name: Refresh container
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.SSH_HOST_PROD }}


### PR DESCRIPTION
…ontainer" in both cd-dev.yml and cd-prod.yml.